### PR TITLE
Fixing ReadUntil statements so time.Time is passed properly.

### DIFF
--- a/dsp.go
+++ b/dsp.go
@@ -78,7 +78,7 @@ func (dsp *KramerAFM20DSP) SendCommand(ctx context.Context, cmd []byte) ([]byte,
 
 	err := dsp.pool.Do(ctx, func(conn connpool.Conn) error {
 		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-
+		readDur := time.Now().Add(3 * time.Second)
 		n, err := conn.Write(cmd)
 		switch {
 		case err != nil:
@@ -87,7 +87,7 @@ func (dsp *KramerAFM20DSP) SendCommand(ctx context.Context, cmd []byte) ([]byte,
 			return fmt.Errorf("wrote %v/%v bytes of command 0x%x", n, len(cmd), cmd)
 		}
 
-		resp, err = conn.ReadUntil(LINE_FEED, 3*time.Second)
+		resp, err = conn.ReadUntil(LINE_FEED, readDur)
 		if err != nil {
 			return fmt.Errorf("unable to read response: %w", err)
 		}

--- a/videoswitcher.go
+++ b/videoswitcher.go
@@ -78,6 +78,7 @@ func (vs *Kramer4x4) SendCommand(ctx context.Context, cmd []byte) ([]byte, error
 	err := vs.pool.Do(ctx, func(conn connpool.Conn) error {
 		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 
+		readDur := time.Now().Add(3 * time.Second)
 		n, err := conn.Write(cmd)
 		switch {
 		case err != nil:
@@ -86,7 +87,7 @@ func (vs *Kramer4x4) SendCommand(ctx context.Context, cmd []byte) ([]byte, error
 			return fmt.Errorf("wrote %v/%v bytes of command 0x%x", n, len(cmd), cmd)
 		}
 
-		resp, err = conn.ReadUntil(LINE_FEED, 3*time.Second)
+		resp, err = conn.ReadUntil(LINE_FEED, readDur)
 		if err != nil {
 			return fmt.Errorf("unable to read response: %w", err)
 		}

--- a/videoswitcherdsp.go
+++ b/videoswitcherdsp.go
@@ -77,6 +77,7 @@ func (vsdsp *KramerVP558) SendCommand(ctx context.Context, cmd []byte, readAgain
 
 	err := vsdsp.pool.Do(ctx, func(conn connpool.Conn) error {
 		_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		readDur := time.Now().Add(3 * time.Second)
 
 		n, err := conn.Write(cmd)
 		switch {
@@ -86,12 +87,12 @@ func (vsdsp *KramerVP558) SendCommand(ctx context.Context, cmd []byte, readAgain
 			return fmt.Errorf("wrote %v/%v bytes of command 0x%x", n, len(cmd), cmd)
 		}
 
-		resp, err = conn.ReadUntil(LINE_FEED, 3*time.Second)
+		resp, err = conn.ReadUntil(LINE_FEED, readDur)
 		if err != nil {
 			return fmt.Errorf("unable to read response: %w", err)
 		}
 		if readAgain {
-			_, err = conn.ReadUntil(LINE_FEED, 3*time.Second)
+			_, err = conn.ReadUntil(LINE_FEED, readDur)
 			if err != nil {
 				return fmt.Errorf("unable to read response: %w", err)
 			}


### PR DESCRIPTION
fixed ReadUntil issue where we were using a time.Duration instead of the time.Time type.  Now duration is calculated before calling ReadUntil and passed to it in the form of a time.Time.